### PR TITLE
Release chart 1.19.4

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 1.19.2
+version: 1.19.4
 appVersion: v2.15.0
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:


### PR DESCRIPTION
## Summary
- bump chart version to 1.19.4 for the next OCI chart release
- keep appVersion at v2.15.0

## Validation
- helm lint .